### PR TITLE
Read default snap delay from global

### DIFF
--- a/Automatic Snapshot.lua
+++ b/Automatic Snapshot.lua
@@ -16,6 +16,8 @@ error_messages = {
     snapshot_required = "You need to take at least one snapshot to load a time lapse.",
 }
 
+local _auto_snap_delay = 1
+
 -- Utility functions
 function check_api_version()
     if app.apiVersion < 15 then
@@ -120,7 +122,7 @@ Snapshot = {}
 
 function Snapshot:_initialize(sprite)
     self.auto_snap_enabled = false
-    self.auto_snap_delay = 1
+    self.auto_snap_delay = _auto_snap_delay
     self.auto_snap_increment = 0
     self.context = nil
 
@@ -323,7 +325,8 @@ if check_api_version() then
         focus = true,
         text = tostring(snapshot.auto_snap_delay),
         onchange = function()
-            snapshot.auto_snap_delay = main_dialog.data.delay
+            _auto_snap_delay = main_dialog.data.delay
+            snapshot.auto_snap_delay = _auto_snap_delay
             snapshot.auto_snap_increment = 0
         end
     }


### PR DESCRIPTION
When changing the action delay on modal before having started the auto snapshot script, it will cause a desync as the process will have reinitialized with a value of 1 regardless of what the modal says.

The fix: Always write to global _auto_snap_delay for initialization to fix desync between script and what modal shows. The initialization process reads from this value now instead of a hardcoded 1.

Should resolve #11 